### PR TITLE
Allow Client Specific Parms To Be Passed In Init

### DIFF
--- a/idme.php
+++ b/idme.php
@@ -32,6 +32,23 @@ class IDME {
     private $AccessToken;
     private $Code;
 
+    /**
+     * function __construct()
+     * Set ClientId / ClientSecret / RedirectUri if passed
+     * into the class
+     * @param type $code
+     */
+    public function __construct( $parameters=null ) {
+        if ( is_array( $parameters ) && isset( $parameters['ClientId'] ) ) {
+            $this->ClientId = $parameters['ClientId'];
+        }
+        if ( is_array( $parameters ) && isset( $parameters['ClientSecret'] ) ) {
+            $this->ClientSecret = $parameters['ClientSecret'];
+        }
+        if ( is_array( $parameters ) && isset( $parameters['RedirectUri'] ) ) {
+            $this->RedirectUri = $parameters['RedirectUri'];
+        }
+    }
     
     /**
      * function verify()


### PR DESCRIPTION
Allow the `ClientId` / `ClientSecret` / `RedirectUri` parameters to be passed in during the class construction instead of hardcoded.

ex:

```
`$idme = new IDME( array(
 'ClientId' => 'testClientId',
 'ClientSecret' => 'testClientSecret',
 'RedirectUri' => 'testRedirectUri',
));
```
